### PR TITLE
Rewrite the "Freezing Object Properties" section

### DIFF
--- a/domc_wiki/defenses/index.md
+++ b/domc_wiki/defenses/index.md
@@ -41,11 +41,22 @@ When attackers can clobber the `src` attribute of dynamically created scripts, t
 However, unlike malicious JavaScript injected by the attacker, injected HTML code is not blocked by CSP. Accordingly, CSP does not mitigate other variants of DOM Clobbering that do not require script `src` manipulation, e.g., clobbering the parameters of dynamic code evaluation constructs `eval` or `new Function()`can lead to CSP-bypassable XSS.
 
 
-### Freezing Object Properties
+### Non-Configurable Object Properties
 
-Another way to mitigate DOM Clobbering is to freeze DOM object properties<sup>[\[3\]](#references)</sup>, e.g., via [Object.freeze()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze) method, which prevents the object to be overwritten by named DOM elements.
+Another way to mitigate DOM Clobbering is to mark DOM object properties as `configurable: false`, e.g., via [`Object.defineProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) (see [\[3\]](#references) for more strategies). For example:
 
-While effective, determining all objects and object properties that need to be frozen is a non-trivial, error-prone task. Also, sealed objects cannot be changed anymore, hindering the dynamic composition of webpages. 
+```js
+// Define a non-configurable property on document to prevent DOM
+// Clobbering from shadowing it.
+Object.defineProperty(document, '<PROPERTY>', {
+  value: "<VALUE>",     // the (initial) value
+  configurable: false,  // prevent redefinition, deletion, and clobbering
+  enumerable: true,     // [OPTIONAL] make it visible during enumeration
+  writable: false,      // [OPTIONAL] prevent changes to the value
+});
+```
+
+While effective, there are some caveats. First, determining all object properties that need to be marked in this way is a non-trivial, error-prone task. Second, this approach does not work if the property is clobbered before defining it. 
 
 
 ### Disabling DOM Clobbering

--- a/domc_wiki/indicators/patterns.md
+++ b/domc_wiki/indicators/patterns.md
@@ -49,7 +49,7 @@ Properties of `document` can always be overwritten by DOM Clobbering, even immed
 - rewrite their application to avoid global values.
 - explicitly add them as properties on `window` (or [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis)), e.g. `window.x=1` - making sure to avoid pattern G and H.
 - use `var` (NOT `let` nor `const`) in the global context to define global values, e.g. `var x=1` - making sure to avoid pattern A, B, and F.
-- initialize global values without `var` (nor `let or `const`), e.g. `x=1` - making sure to avoid pattern E, G, and H.
+- initialize global values without `var` (nor `let` or `const`), e.g. `x=1` - making sure to avoid pattern E, G, and H.
 
 The following table shows how declerations affect global value access patterns in the precense of DOM Clobbering.
 


### PR DESCRIPTION
Closes #13

This rewrites the existing [Freezing Object Properties section](https://github.com/SoheilKhodayari/DOMClobbering/blob/fd534e8599280234d31ebeff89575f4a257608d7/domc_wiki/defenses/index.md#freezing-object-properties) to a section about marking properties as non-configurable. I'm not sure what to do with the 3rd [reference](https://domclob.xyz/domc_wiki/defenses/#references) since I don't have access to it...

I hope this covers the discussion in #13 accurately, changing the focus of the section to `Object.defineProperty` (or, more specifically, using `configurable:false`) and omitting `Object.freeze` (and related language) because of its limited and browser-specific use. I did verify that clobbering before defining fails (as written), and also checked whether you can (re)`defineProperty` standard document properties such as `head` and it seems you can! Let me know if you think there's something to improve about my changes or if there's something else we should test 🙂 

Also, I included a correction for a typo I made in #12.